### PR TITLE
Fix path to manifest (changed in Vite 5)

### DIFF
--- a/public/helpers.php
+++ b/public/helpers.php
@@ -100,7 +100,7 @@ function cssTag(string $entry): string
 
 function getManifest(): array
 {
-    $content = file_get_contents(__DIR__ . '/dist/manifest.json');
+    $content = file_get_contents(__DIR__ . '/dist/.vite/manifest.json');
     return json_decode($content, true);
 }
 


### PR DESCRIPTION
This is a breaking change in Vite 5.0 as pointed out [here in the docs](https://vitejs.dev/guide/migration.html#manifest-files-are-now-generated-in-vite-directory-by-default).